### PR TITLE
Adding textadept to list

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -68,6 +68,20 @@ html(lang="en")
             p.last-update(title="Last update") 2015-08-16
 
           li
+            a(name="textadept")
+            h2 Textadept
+            p.packages
+              | Important packages:
+              a(href="https://github.com/abaez/ta-rust") ta-rust
+              | ,
+              a(href="https://github.com/abaez/ta-toml") ta-toml
+            p.specific
+              | Specific highlights:
+              | Textadept is one of the few editors with syntax highlighting out-of-the-box.
+              | The module has built in scripts to run rustc with simple syntax checking and cargo support.
+            p.last-update(title="Last update") 2015-10-13
+
+          li
             a(name="sublime")
             h2 Sublime Text 2/3
             p.packages


### PR DESCRIPTION
Here is a proposal to potentially add my Textadept [module for rust](https://github.com/abaez/ta-rust)
to the list. The texteditor plugin was written a year ago and after a
small exodus, has been reinvigorated with commits. It currently has
the following features:

* Syntax highlighting out-of-the-box: updated by stable releases.
* Snippets: always expanding and easy to append your own.
* Code completion: light self written and currently being updated to
also use racer for the task.
* Linting: using rustfmt for lint.
* Go-to definition: using ctags generated for projects during a cargo
build executed directly in textadept.
* Syntax checking: very simple using rustc post compile executed in
textadept. Will be expanded to use oracle.
* API reference: both from std rust and cargo built projects on
textadept.