### PR TITLE
Add Debugging and Doc Tooltips Columns

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -148,8 +148,12 @@ html(lang="en")
             p.packages
               | Important packages:
               a(href="https://marketplace.visualstudio.com/items/saviorisdead.RustyCode") Rusty Code
-            p.last-update(tilte="Last update") 2015-12-01
-            
+              | , 
+              a(href="https://marketplace.visualstudio.com/items?itemName=webfreak.debug") Debug
+              | , 
+              a(href="https://marketplace.visualstudio.com/items?itemName=be5invis.toml") TOML Language Support
+            p.last-update(tilte="Last update") 2016-05-17
+
 
 
       section

--- a/table.jade
+++ b/table.jade
@@ -15,7 +15,9 @@ table#overview
       th
         div Go-to Definition
       th
-        div Syntax Checking
+        div Debugging
+      th
+        div Documentation Tooltips
   tbody
     tr
       th.name
@@ -26,7 +28,8 @@ table#overview
       td.completion ✓<sup>2</sup>
       td.linting ✓<sup>1</sup>
       td.goto ✓<sup>2</sup>
-      td.syntaxcheck
+      td.debugging
+      td.doctooltips
     tr
       th.name
         a(href="#bbedit") BBedit
@@ -36,7 +39,8 @@ table#overview
       td.completion
       td.linting
       td.goto
-      td.syntaxcheck
+      td.debugging
+      td.doctooltips
     tr
       th.name
         a(href="#emacs") Emacs
@@ -46,7 +50,8 @@ table#overview
       td.completion ✓<sup>2</sup>
       td.linting ✓<sup>1</sup>
       td.goto ✓<sup>2</sup>
-      td.syntaxcheck ✓<sup>1</sup>
+      td.debugging
+      td.doctooltips
     tr
       th.name
         a(href="#geany") Geany
@@ -56,7 +61,8 @@ table#overview
       td.completion
       td.linting
       td.goto
-      td.syntaxcheck
+      td.debugging
+      td.doctooltips
     tr
       th.name
         a(href="#kate") Kate
@@ -66,7 +72,8 @@ table#overview
       td.completion ✓<sup>2</sup>
       td.linting
       td.goto
-      td.syntaxcheck
+      td.debugging
+      td.doctooltips
     //-tr
     //-  th.name
     //-    a(href="#notepad") Notepad++
@@ -80,7 +87,8 @@ table#overview
       td.completion ✓<sup>1</sup>
       td.linting ✓<sup>1</sup>
       td.goto ✓<sup>1</sup>
-      td.syntaxcheck ✓<sup>1</sup>
+      td.debugging
+      td.doctooltips
     tr
       th(title="Sublime Text 2/3").name
         a(href="#sublime") Sublime
@@ -90,7 +98,8 @@ table#overview
       td.completion ✓<sup>2</sup>
       td.linting ✓<sup>1</sup>
       td.goto ✓<sup>2</sup>
-      td.syntaxcheck
+      td.debugging
+      td.doctooltips
     tr
       th.name
         a(href="#vim") Vim
@@ -98,18 +107,20 @@ table#overview
       //-td.tomlhighlighting
       td.snippets ✓<sup>1</sup>
       td.completion ✓<sup>2</sup>
-      td.linting
+      td.linting ✓<sup>1</sup>
       td.goto ✓<sup>2</sup>
-      td.syntaxcheck ✓<sup>1</sup>
+      td.debugging
+      td.doctooltips
     tr
       th.name
         a(href="#vscode") VS Code
       td.highlighting ✓
       td.snippets ✓
       td.completion ✓<sup>2</sup>
-      td.linting
+      td.linting  ✓<sup>1</sup>
       td.goto ✓<sup>2</sup>
-      td.syntaxcheck
+      td.debugging ✓<sup>1</sup>
+      td.doctooltips ✓<sup>2</sup>
     //--------
     //- IDEs -
     //--------
@@ -122,17 +133,19 @@ table#overview
       td.completion ✓<sup>2</sup>
       td.linting
       td.goto ✓<sup>1</sup>
-      td.syntaxcheck
+      td.debugging ✓<sup>1</sup>
+      td.doctooltips
     tr
       th.name
-        a(href="#visualstudio") Visual Studio
-      td.highlighting ✓
+        a(href="#intellij") IntelliJ IDEA
+      td.highlighting ✓<sup>1</sup>
       //-td.tomlhighlighting
-      td.snippets
-      td.completion ✓<sup>2</sup>
-      td.linting
-      td.goto ✓<sup>1</sup>
-      td.syntaxcheck
+      td.snippets ✓<sup>1</sup>
+      td.completion
+      td.linting ✓<sup>1</sup>
+      td.goto
+      td.debugging
+      td.doctooltips
     tr
       th.name
         a(href="#solidoak") SolidOak
@@ -142,17 +155,19 @@ table#overview
       td.completion ✓<sup>2</sup>
       td.linting
       td.goto
-      td.syntaxcheck
+      td.debugging
+      td.doctooltips
     tr
       th.name
-        a(href="#intellij") IntelliJ IDEA
-      td.highlighting ✓<sup>1</sup>
+        a(href="#visualstudio") Visual Studio
+      td.highlighting ✓
       //-td.tomlhighlighting
-      td.snippets ✓<sup>1</sup>
-      td.completion
+      td.snippets
+      td.completion ✓<sup>2</sup>
       td.linting
-      td.goto
-      td.syntaxcheck ✓<sup>1</sup>
+      td.goto ✓<sup>1</sup>
+      td.debugging ✓<sup>1</sup>
+      td.doctooltips
 
 #overviewlegend
   p


### PR DESCRIPTION
Visual Studio Code's RustyCode plugin has lots of cool new features that are not reflected on areweideyet, so additional columns should be added. 

This also gets rid of the Syntax Checking column, as it's pretty unclear what that even means, as linting is also Syntax Checking, which made the table pretty inaccurate. 

I'm not sure if the column should be "Documentation Tooltips" or just "Show Documentation". Showing the Documentation is something the other editors are somewhat capable of too, but only in the browser. They don't parse the documentation and render it specifically, which is a pretty cool and distinguishing feature that VS Code has, so it should be highlighted.

Here's how that looks like (as you can see, it's pretty cool):
![http://puu.sh/oEI7U.png](http://puu.sh/oEI7U.png)