### PR TITLE
Add information about the GNOME Builder IDE

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -254,6 +254,22 @@ html(lang="en")
               |  where he shows recordings of him programming ride.
             p.last-update(title="Last update") 2016-10-10
 
+          li
+            a(name="gnome-builder")
+            h2 GNOME Builder
+            p
+              | With GNOME Builder you get out of the box
+            ul.features
+              li build integration with cargo
+              li semantic syntax highlighter that knows about your types
+              li autocomplete
+              li go to definition (including code from base Rust libraries and other third party libraries)
+              li as-you-type diagnostics
+              li rename symbol
+              li document symbol tree
+              li toolchain management powered by rustup
+            p.last-update(title="Last update") 2017-02-20
+
       section
         h1 Meta
 

--- a/table.jade
+++ b/table.jade
@@ -169,6 +169,17 @@ table#overview
       td.goto ✓<sup>1</sup>
       td.debugging ✓<sup>1</sup>
       td.doctooltips
+    tr
+      th.name
+        a(href="#gnome-builder") GNOME Builder
+      td.highlighting ✓
+      //-td.tomlhighlighting
+      td.snippets ✓
+      td.completion ✓
+      td.linting ✓
+      td.goto ✓
+      td.debugging
+      td.doctooltips
     tr.show_more
       td(colspan="8") Show more IDEs ⇩
     //--------


### PR DESCRIPTION
This includes information on native Rust support that is shipped with the
GNOME Builder IDE.