### PR TITLE
Emacs provides tooltips via emacs-racer and eldoc

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -92,7 +92,7 @@ html(lang="en")
               a(href="https://github.com/racer-rust/emacs-racer") emacs-racer
               | , 
               a(href="https://github.com/freebroccolo/rust-snippets") rust-snippets
-            p.last-update(title="Last update") 2017-02-23
+            p.last-update(title="Last update") 2018-03-04
 
           li
             a(name="mc")

--- a/table.jade
+++ b/table.jade
@@ -56,7 +56,7 @@ table#overview
       td.formatting ✓<sup>1</sup>
       td.goto ✓<sup>2</sup>
       td.debugging
-      td.doctooltips
+      td.doctooltips ✓<sup>2</sup>
     tr
       th.name
         a(href="#mc") Midnight Commander


### PR DESCRIPTION
(eldoc is an Emacs built-in package)

Is this the right way to document it?