### PR TITLE
Updated references to the VSCode Rust plugin

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -190,17 +190,14 @@ html(lang="en")
             h2 VS Code
             p.packages
               | Important packages:
-              a(href="https://marketplace.visualstudio.com/items?itemName=kalitaalexey.vscode-rust") Rust
+              a(href="https://marketplace.visualstudio.com/items?itemName=rust-lang.rust") Rust
               | ,
               a(href="https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb") CodeLLDB
               | , 
               a(href="https://marketplace.visualstudio.com/items?itemName=webfreak.debug") Debug
               | , 
               a(href="https://marketplace.visualstudio.com/items?itemName=be5invis.toml") TOML Language Support
-            p
-              | If you encounter problems with rustfmt, consider 
-              a(href="https://github.com/editor-rs/vscode-rust/issues/270#issuecomment-307500142") downgrading it.
-            p.last-update(tilte="Last update") 2017-08-06
+            p.last-update(tilte="Last update") 2018-04-11
             
 
 


### PR DESCRIPTION
The [vscode-rust](https://marketplace.visualstudio.com/items?itemName=kalitaalexey.vscode-rust) plugin is now unmaintained, while the [rust](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust) plugin is maintained directly by the RLS team.