### PR TITLE
Include neovim packages, check "documentation" box for vim-racer, check "debugging" box for lldb.nvim

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -186,6 +186,21 @@ html(lang="en")
                   |  (relying on 
                   a(href="https://github.com/sirver/ultisnips") UltiSnips
                   | )
+            p.packages
+              | Important Neovim-only packages:
+              ul
+                li
+                  a(href="https://github.com/dbgx/lldb.nvim") lldb.nvim
+                  |  (
+                  a(href="https://github.com/dbgx/lldb.nvim/commit/56dfc2d945") unmaintained
+                  |  as of 2018-03-11)
+                li
+                  a(href="https://github.com/roxma/nvim-cm-racer") nvim-cm-racer
+                  |  (relying on 
+                  a(href="https://github.com/roxma/nvim-completion-manager") nvim-completion-manager
+                  | , which is 
+                  a(href="https://github.com/roxma/nvim-completion-manager/issues/12#issuecomment-382334422") unmaintained
+                  |  as of 2018-04-18)
             p.last-update(title="Last update") 2016-01-12
           li
             a(name="vscode")

--- a/index.jade
+++ b/index.jade
@@ -201,7 +201,7 @@ html(lang="en")
                   | , which is 
                   a(href="https://github.com/roxma/nvim-completion-manager/issues/12#issuecomment-382334422") unmaintained
                   |  as of 2018-04-18)
-            p.last-update(title="Last update") 2016-01-12
+            p.last-update(title="Last update") 2018-05-06
           li
             a(name="vscode")
             h2 VS Code

--- a/index.jade
+++ b/index.jade
@@ -171,19 +171,21 @@ html(lang="en")
             a(name="vim")
             h2 Vim
             p.packages
-              | Important packages: 
-              a(href="https://github.com/rust-lang/rust.vim") rust.vim
-              | , 
-              a(href="http://blog.jwilm.io/youcompleteme-rust") YouCompleteMe-rust
-              | , 
-              a(href="https://github.com/racer-rust/vim-racer") vim-racer
-              | , 
-              a(href="https://github.com/scrooloose/syntastic") syntastic
-              | , 
-              a(href="https://github.com/honza/vim-snippets") vim-snippets
-              | (relying on
-              a(href="https://github.com/sirver/ultisnips") UltiSnips
-              | )
+              | Important packages:
+              ul
+                li
+                  a(href="https://github.com/rust-lang/rust.vim") rust.vim
+                li
+                  a(href="http://blog.jwilm.io/youcompleteme-rust") YouCompleteMe-rust
+                li
+                  a(href="https://github.com/racer-rust/vim-racer") vim-racer
+                li
+                  a(href="https://github.com/scrooloose/syntastic") syntastic
+                li
+                  a(href="https://github.com/honza/vim-snippets") vim-snippets
+                  |  (relying on 
+                  a(href="https://github.com/sirver/ultisnips") UltiSnips
+                  | )
             p.last-update(title="Last update") 2016-01-12
           li
             a(name="vscode")

--- a/index.jade
+++ b/index.jade
@@ -169,7 +169,7 @@ html(lang="en")
             
           li
             a(name="vim")
-            h2 Vim
+            h2 Vim and Neovim
             p.packages
               | Important packages:
               ul

--- a/table.jade
+++ b/table.jade
@@ -105,7 +105,7 @@ table#overview
       td.formatting ✓<sup>1</sup>
       td.goto ✓<sup>2</sup>
       td.debugging
-      td.doctooltips
+      td.doctooltips ✓<sup>2</sup>
     tr
       th.name
         a(href="#vscode") VS Code

--- a/table.jade
+++ b/table.jade
@@ -96,7 +96,7 @@ table#overview
       td.doctooltips
     tr
       th.name
-        a(href="#vim") Vim
+        a(href="#vim") Vim/Neovim
       td.highlighting ✓<sup>1</sup>
       //-td.tomlhighlighting
       td.snippets ✓<sup>1</sup>


### PR DESCRIPTION
Satisfies #61.

* vim-racer supports opening documentation for code under the cursor, including this under "Documentation Tooltips" in the table.
* dbgx/lldb.nvim and roxma/nvim-cm-racer are important Neovim plugins, listing them
* Because we list Neovim plugins now, the "Vim" titles include "Neovim" and the packages list is changed to unordered lists for spacing.