### PR TITLE
Vim and Neovim support Rust syntax highlighting and indenting out of box

### DIFF
--- a/table.jade
+++ b/table.jade
@@ -84,7 +84,7 @@ table#overview
     tr
       th.name
         a(href="#vim") Vim/Neovim
-      td.highlighting ✓<sup>1</sup>
+      td.highlighting ✓
       //-td.tomlhighlighting
       td.snippets ✓<sup>1</sup>
       td.completion ✓<sup>2</sup>


### PR DESCRIPTION
Vim and Neovim contains Rust support by default. It provides basic syntax highlighting and indentation out of box.

Vim: https://github.com/vim/vim/blob/master/runtime/syntax/rust.vim
Neovim: https://github.com/neovim/neovim/blob/master/runtime/syntax/rust.vim