### PR TITLE
Emacs supports TOML out of the box

### DIFF
--- a/table.jade
+++ b/table.jade
@@ -37,7 +37,7 @@ table#overview
       th.name
         a(href="#emacs") Emacs
       td.highlighting ✓<sup>1</sup>
-      td.tomlhighlighting
+      td.tomlhighlighting ✓
       td.snippets ✓<sup>1</sup>
       td.completion ✓<sup>1</sup>
       td.linting ✓<sup>1</sup>


### PR DESCRIPTION
Emacs has `toml-conf-mode` included by default, which includes TOML syntax highlighting