### PR TITLE
Updates to IntelliJ-based IDEs section

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -263,16 +263,29 @@ html(lang="en")
 
           li
             a(name="intellij")
-            h2 IntelliJ IDEA
+            h2 IntelliJ-based IDEs
             p.packages
-              | Important packages:
-              a(href="https://intellij-rust.github.io/") intellij-rust
+              | Plugins:
+              a(href="https://plugins.jetbrains.com/plugin/8182-rust") intellij-rust
+              | and
+              a(href="https://plugins.jetbrains.com/plugin/8195-toml") intellij-toml
+              |
             p
-              | Debugging is also supported via CLion. Check the 
-              a(href="https://github.com/intellij-rust/intellij-rust/issues/535") discussion 
-              | for progress.
-
-            p.last-update(title="Last update") 2017-08-06
+              | The plugins bring Rust and TOML support to 
+              a(href="https://www.jetbrains.com/idea/") IDEA
+              |, 
+              a(href="https://www.jetbrains.com/clion/") CLion
+              |, 
+              a(href="https://www.jetbrains.com/pycharm/") PyCharm
+              |, and other JetBrains IDEs.
+            p
+              | Language support includes syntax highlighting, completion,
+              | navigation, and other 
+              a(href="https://intellij-rust.github.io/features/") code insight features
+              |. You can work with Cargo commands and run Clippy or Rustfmt without leaving the IDE.
+            p
+              | Debugger and profiler are available in CLion.
+            p.last-update(title="Last update") 2019-08-03
 
           li
             a(name="ride")

--- a/table.jade
+++ b/table.jade
@@ -174,9 +174,9 @@ table#overview
       td.doctooltips ✓<sup>1</sup>
     tr
       th.name
-        a(href="#intellij") IntelliJ IDEA
+        a(href="#intellij") IntelliJ-based IDEs
       td.highlighting ✓<sup>1</sup>
-      td.tomlhighlighting
+      td.tomlhighlighting ✓<sup>1</sup>
       td.snippets ✓<sup>1</sup>
       td.completion ✓<sup>1</sup>
       td.linting ✓<sup>1</sup>


### PR DESCRIPTION
Please consider the following updates regarding IntelliJ.
Plugins for Rust and TOML are compatible with all IntelliJ-based IDEs, including but not limited to IDEA. They are mostly used in IDEA, CLion, and PyCharm.  But debugging for Rust is currently available in CLion only.
In this commit:
1) table: the row 'IntelliJ IDEA' renamed into 'IntelliJ-based IDEs' and toml marked as supported.
2) text: title changed to 'IntelliJ-based IDEs' and text updated.
