### PR TITLE
The JetBrains Rust plugin now pulls in TOML too.

### DIFF
--- a/table.jade
+++ b/table.jade
@@ -176,7 +176,7 @@ table#overview
       th.name
         a(href="#intellij") IntelliJ IDEA
       td.highlighting ✓<sup>1</sup>
-      td.tomlhighlighting
+      td.tomlhighlighting ✓<sup>1</sup>
       td.snippets ✓<sup>1</sup>
       td.completion ✓<sup>1</sup>
       td.linting ✓<sup>1</sup>


### PR DESCRIPTION
As of 2019-08-12, [IntelliJ Rust will automatically pull in a TOML plugin when installed](https://intellij-rust.github.io/2019/08/12/changelog-103.html), de facto supporting TOML. I've changed the table to reflect this.