### PR TITLE
update info about kate

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -106,9 +106,11 @@ html(lang="en")
             h2 Kate
             p.specific
               | Specific highlights:
-              | Kate is one of the few editors with syntax highlighting out-of-the-box. 
-              | Plus, there is also support for Racer and through that autocompletion. Activate it with: 
-              | Settings > Configure Kate > Plugins > Rust Code completion.
+              | Kate provides Rust and .toml syntax highlighting out of the box.
+              | Plus, there is also support for rls and through that autocompletion, 
+              | linting, code formatting and go-to definition.
+              | Activate it with:
+              | Settings > Configure Kate > Plugins > LSP Client.
             p.last-update(title="Last update") 2017-08-19
 
           li

--- a/index.jade
+++ b/index.jade
@@ -111,7 +111,7 @@ html(lang="en")
               | linting, code formatting and go-to definition.
               | Activate it with:
               | Settings > Configure Kate > Plugins > LSP Client.
-            p.last-update(title="Last update") 2017-08-19
+            p.last-update(title="Last update") 2020-05-08
 
           li
             a(name="textadept")

--- a/table.jade
+++ b/table.jade
@@ -137,12 +137,12 @@ table#overview
       th.name
         a(href="#kate") Kate
       td.highlighting ✓
-      td.tomlhighlighting
+      td.tomlhighlighting ✓ 
       td.snippets
       td.completion ✓<sup>1</sup>
-      td.linting
-      td.formatting
-      td.goto
+      td.linting ✓<sup>1</sup> 
+      td.formatting ✓<sup>1</sup> 
+      td.goto ✓<sup>1</sup>
       td.debugging
       td.doctooltips
     tr


### PR DESCRIPTION
Regarding #90 
I updated description and table to reflect changes in rust support for kate.

Kate no longer features a separate plugin for rust as it now works with rls through **LSP Client** plugin which provides more features.