### PR TITLE
Update inspiration link to reflect actual URL

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -362,7 +362,7 @@ html(lang="en")
             p
               | Inspiration:
               br
-              a(href="http://arewewebyet.com/") Are we web yet?
+              a(href="https://www.arewewebyet.org/") Are we web yet?
           li
             p
               | Licensed under:


### PR DESCRIPTION
The url that was in place until now has nothing to do with the actual url. It might even be a malicious website as multiple suspicious looking scripts are blocked by uBlock when accessing the site. I do not know how critical the situation is but please change this as fast as possible.

![grafik](https://user-images.githubusercontent.com/52202086/87876816-c3029000-c9da-11ea-9a2b-3aefd7cd3c02.png)

Here are the domain lookups for the two domains.

- [Correct: (AreWeWebYet.org)](https://whois.domaintools.com/arewewebyet.org)
- [Wrong: (AreWeWebYet.com)](https://whois.domaintools.com/arewewebyet.com)
