### PR TITLE
IntelliJ-based IDEs: debugging is now supported in IDEA Ultimate

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -288,7 +288,7 @@ html(lang="en")
               a(href="https://intellij-rust.github.io/features/") code insight features
               |. You can work with Cargo commands and run Clippy or Rustfmt without leaving the IDE.
             p
-              | Debugger is available in CLion and IntelliJ IDEA Ultimate.
+              | Debugger is available in CLion and IntelliJ IDEA Ultimate. CLion's integration also supports CPU profiling.
             p.last-update(title="Last update") 2019-08-03
 
           li

--- a/index.jade
+++ b/index.jade
@@ -288,7 +288,7 @@ html(lang="en")
               a(href="https://intellij-rust.github.io/features/") code insight features
               |. You can work with Cargo commands and run Clippy or Rustfmt without leaving the IDE.
             p
-              | Debugger and profiler are available in CLion.
+              | Debugger is available in CLion and IntelliJ IDEA Ultimate.
             p.last-update(title="Last update") 2019-08-03
 
           li


### PR DESCRIPTION
Please update the info on debugger support in IntelliJ-based IDEs.
Debugger is now supported in IntelliJ IDEA Ultimate version 2020.1 and later. The initial announcement in the plugin's changelog: https://intellij-rust.github.io/2020/04/27/changelog-121.html