### PR TITLE
IntelliJ-based IDEs: correction on debugger/profiler

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -288,10 +288,7 @@ html(lang="en")
               a(href="https://intellij-rust.github.io/features/") code insight features
               |. You can work with Cargo commands and run Clippy or Rustfmt without leaving the IDE.
             p
-              | Debugger and profiler are available in CLion and IntelliJ IDEA Ultimate. CLion's integration also supports CPU profiling.. For all other IDEs, Debugging is 
-              | possible using the 
-              a(href="https://plugins.jetbrains.com/plugin/12775-native-debugging-support/") Native Debugging
-              | plugin.
+              | Debugger is available in CLion and IntelliJ IDEA Ultimate. CLion's integration also supports CPU profiling.
             p.last-update(title="Last update") 2020-07-29
 
           li


### PR DESCRIPTION
Unfortunately, the current info is not 100% correct: "Debugger and profiler are available in CLion and IntelliJ IDEA Ultimate. CLion's integration also supports CPU profiling.. For all other IDEs, Debugging is possible using the Native Debuggingplugin."

Debugging is not available in all IDEs, it works in CLion and IntelliJ IDEA Ultimate (in this latter case it requires the additional Native Debugging plugin, but it's not critically important to state this since this plugin installs automatically). 
Also, profiler is available in CLion only.

Could you please correct the info? Let's say this way: "Debugger is available in CLion and IntelliJ IDEA Ultimate. CLion's integration also supports CPU profiling."

Thank you!