### PR TITLE
typo

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -299,7 +299,7 @@ html(lang="en")
               a(href="https://intellij-rust.github.io/features/") code insight features
               |. You can work with Cargo commands and run Clippy or Rustfmt without leaving the IDE.
             p
-              | Debugger is available in CLion and IntelliJ IDEA Ultimate. CLion's integration also supports CPU profiling.
+              | Debugger is available in CLion and IntelliJ IDEA Ultimate. CLion's integration also supports CPU profiling
             p.last-update(title="Last update") 2020-07-29
 
           li


### PR DESCRIPTION
Hi! For some reason my last [pr](https://github.com/contradictioned/areweideyet/pull/97), although merged, has not landed in prod https://areweideyet.com/.  There is still a line 'For all other IDEs, Debugging is possible using the Native Debugging plugin.', which was meant to be removed. So I'm trying one more time (and fixing a typo with an extra dot along the way) :)
Thanks!